### PR TITLE
update s.t. it works with latest FEU module (currently v. 1.21.15)

### DIFF
--- a/src/DownloadManager.module.php
+++ b/src/DownloadManager.module.php
@@ -906,9 +906,9 @@ class DownloadManager extends CMSModule
 	if(!$FEU->LoggedIn())	return false;
 
 	$userid = $FEU->LoggedInId();
-	$usergroups = explode(',',$FEU->GetMemberGroups($userid));
 	$groups = $FEU->GetGroupList();
 	$filegroups = $this->GetFileGroups($file_id);
+	$usergroups = $FEU->GetMemberGroupsArray($userid);
 	
 	// check if any group is needed to access
 	if(empty($filegroups))
@@ -919,7 +919,11 @@ class DownloadManager extends CMSModule
 	$i = 0;
 	while(!$hasperm && $i < count($usergroups))
 	{
-	    if(in_array($groups[$usergroups[$i]],$filegroups))	$hasperm = true;
+		if(in_array($usergroups[$i]['groupid'],$filegroups))	
+		{
+			$hasperm = true;
+			break;
+		}
 	    $i++;
 	}
 	return $hasperm;


### PR DESCRIPTION
Here is a fix which allow DownloadManager to work with latest FrontEndUser module. Apparently recent changes in this module broke the function retrieving the groups of the current Frontend user.
